### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of our GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Summary
This PR addresses Issue #6 by adding the missing **GitHub Skills** activity that was announced by the principal.

## Changes
- Added "GitHub Skills" to the activities dictionary in `app.py`
- Description includes reference to the GitHub Certifications program for college applications
- Schedule: Mondays and Thursdays, 3:30 PM - 5:00 PM
- Max participants: 25 students
- Ready for immediate student registration

## Issue Context
The principal announced this activity in the school assembly, and students have been unable to sign up because it was missing from the system. This is time-sensitive as registrations close by the end of this week.

Fixes #6